### PR TITLE
Potential fix for code scanning alert no. 1: Unused global variable

### DIFF
--- a/tools/_run.py
+++ b/tools/_run.py
@@ -5,8 +5,6 @@ from pathlib import Path
 import subprocess
 import sys
 
-_VENV_NOTICE_PRINTED = False
-
 
 def python_executable(repo_root: Path) -> str:
     """
@@ -15,7 +13,10 @@ def python_executable(repo_root: Path) -> str:
     This avoids confusing "missing dependency" errors when users run `python -m tools.*`
     without activating the virtual environment first.
     """
-    global _VENV_NOTICE_PRINTED
+
+    # Track whether we've already printed a `.venv` notice, without using a module-level global.
+    if not hasattr(python_executable, "_venv_notice_printed"):
+        python_executable._venv_notice_printed = False  # type: ignore[attr-defined]
 
     if os.environ.get("VIRTUAL_ENV"):
         return sys.executable
@@ -27,8 +28,11 @@ def python_executable(repo_root: Path) -> str:
     ]
     for candidate in candidates:
         if candidate.exists():
-            if not _VENV_NOTICE_PRINTED and str(candidate) != sys.executable:
-                _VENV_NOTICE_PRINTED = True
+            if (
+                not python_executable._venv_notice_printed  # type: ignore[attr-defined]
+                and str(candidate) != sys.executable
+            ):
+                python_executable._venv_notice_printed = True  # type: ignore[attr-defined]
                 print(
                     f"info: detected local .venv, using {candidate}. "
                     "Activate it to match: "
@@ -42,8 +46,8 @@ def python_executable(repo_root: Path) -> str:
     if os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CI") == "true":
         return sys.executable
 
-    if not _VENV_NOTICE_PRINTED:
-        _VENV_NOTICE_PRINTED = True
+    if not python_executable._venv_notice_printed:  # type: ignore[attr-defined]
+        python_executable._venv_notice_printed = True  # type: ignore[attr-defined]
         print(
             "warning: no local `.venv` detected and no active virtual environment. "
             "If you hit missing-tool errors, run `bash scripts/bootstrap_venv.sh` "


### PR DESCRIPTION
Potential fix for [https://github.com/tuanductran/soulmap-ai/security/code-scanning/1](https://github.com/tuanductran/soulmap-ai/security/code-scanning/1)

In general, to fix an “unused global variable” that is only used inside a single function, you should avoid storing state in a module-level global if it isn’t needed outside that function. Instead, keep the state local to the function (e.g., with a default argument, closure, or function attribute), or remove it entirely if it’s not needed. This both satisfies the static analysis rule and reduces global state.

Here, `_VENV_NOTICE_PRINTED` is used solely to ensure that the informational/warning messages are printed at most once per process, across multiple calls to `python_executable`. We can preserve that behavior without a global by attaching a small bit of state to the function itself. The steps:

1. Remove the module-level definition `_VENV_NOTICE_PRINTED = False`.
2. Remove `global _VENV_NOTICE_PRINTED` from inside `python_executable`.
3. Replace usages of `_VENV_NOTICE_PRINTED` with an internal helper that reads/writes a function attribute, e.g. `python_executable._venv_notice_printed`.
4. Initialize this attribute lazily on first use (so there is no need for a separate top-level assignment).

All changes occur in `tools/_run.py` within the shown snippet. No additional imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
