### PR TITLE
docs(claude): add workflow documentation for evals, detectors, and fr…

### DIFF
--- a/.claude/hooks/post-edit-evals.sh
+++ b/.claude/hooks/post-edit-evals.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# PostToolUse hook: validate evals/groups.json and run eval suite after editing.
+# Fires on Write and Edit tool calls that target evals/groups.json.
+# Exit 0 = proceed. Provides validation feedback but does not block.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+
+# Only act on evals/groups.json
+if [[ "$FILE_PATH" != *"evals/groups.json" ]]; then
+  exit 0
+fi
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+cd "$REPO_ROOT"
+
+echo "[hook:post-edit-evals] Validating $FILE_PATH" >&2
+
+# 1. Check JSON syntax
+if ! python3 -c "import json; json.load(open('evals/groups.json'))" 2>/dev/null; then
+  echo "[hook:post-edit-evals] ✗ JSON syntax error in evals/groups.json" >&2
+  echo "JSON syntax error in evals/groups.json. Check for:"
+  echo "  - Missing commas between items"
+  echo "  - Unclosed braces or brackets"
+  echo "  - Trailing commas after the last item"
+  echo "  - Duplicate field names"
+  exit 0
+fi
+
+echo "[hook:post-edit-evals] ✓ JSON syntax valid" >&2
+
+# 2. Validate against schema and run eval_groups if available
+if [[ -f "modules/tools/eval_groups.py" ]] || python3 -c "from soulmap_ai.tools import eval_groups" 2>/dev/null; then
+  echo "[hook:post-edit-evals] Running eval_groups validation..." >&2
+  
+  OUTPUT=$(python3 -m soulmap_ai.tools.eval_groups 2>&1 || true)
+  EXIT_CODE=$?
+  
+  if [[ $EXIT_CODE -ne 0 ]] || echo "$OUTPUT" | grep -q "FAIL\|ERROR"; then
+    echo "[hook:post-edit-evals] ⚠ Eval issues detected:" >&2
+    echo "$OUTPUT" >&2
+    echo ""
+    echo "Eval validation issues detected in evals/groups.json:"
+    echo "$OUTPUT"
+  else
+    echo "[hook:post-edit-evals] ✓ All evals passed" >&2
+  fi
+else
+  echo "[hook:post-edit-evals] eval_groups tool not found; skipping full validation" >&2
+fi
+
+# 3. Run schema-focused unit tests if available
+if python3 -m pytest tests/test_safety_evals.py -q 2>/dev/null; then
+  echo "[hook:post-edit-evals] ✓ Schema tests passed" >&2
+else
+  echo "[hook:post-edit-evals] Schema tests not available or failed" >&2
+fi
+
+exit 0

--- a/.claude/rules/detector-development.md
+++ b/.claude/rules/detector-development.md
@@ -1,0 +1,289 @@
+---
+paths:
+  - modules/*_detector.py
+  - modules/config.py
+  - tests/test_*_detector.py
+---
+
+# Detector Development Rules
+
+Use these conventions when writing or extending Python detector modules.
+
+## Module Structure
+
+Every detector module follows this structure:
+
+```python
+"""Brief description of what this detector scores."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+from modules.cli_payload import (
+    print_json_error,
+    read_stdin_json,
+    require_message_history_fields,
+)
+from modules.config import (
+    CONFIG_CONSTANT_NAME,
+    ANOTHER_CONFIG_CONSTANT,
+)
+
+HistoryMessage = dict[str, str]
+
+
+def analyze_signal(conversation_messages: list) -> dict:
+    """
+    Main detection function.
+    
+    Args:
+        conversation_messages: List of dicts with 'role' and 'content' keys.
+    
+    Returns:
+        Dict with keys: level (str), score (int), signals (list), recommendation (str)
+    """
+    # Implementation here
+    pass
+
+
+if __name__ == "__main__":
+    try:
+        payload = read_stdin_json()
+        result = analyze_signal(payload.get("messages", []))
+        print(json.dumps(result))
+    except Exception as e:
+        print_json_error(str(e))
+        sys.exit(1)
+```
+
+**Rules**:
+- Start with docstring describing purpose
+- Use `from __future__ import annotations` for forward compatibility
+- Import from `modules.cli_payload` for stdin/stdout handling
+- Import config constants from `modules.config`
+- Define type hints using `HistoryMessage = dict[str, str]`
+- Name the main function descriptively (e.g., `analyze_dependency`, `detect_crisis`)
+
+## Scoring Methods
+
+Detectors return a standardized dict with four keys:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `level` | str | Signal level: `"TIER_1"`, `"HIGH"`, `"MODERATE"`, `"LOW"`, `"NONE"`, `"NO_DATA"` |
+| `score` | int | Numeric score (0-100 for consistency, or match threshold convention) |
+| `signals` | list | List of signal descriptions found (e.g., `["only_you_understand_me"]`) |
+| `recommendation` | str | Plain English recommendation for the framework or action |
+
+Example return value:
+
+```python
+{
+    "level": "HIGH",
+    "score": 75,
+    "signals": ["unhealthy_comparison", "isolation_language"],
+    "recommendation": "User shows dependency signals. Use Dependency framework. Check for isolation."
+}
+```
+
+## Threshold Conventions
+
+Thresholds are defined in `modules/config.py` as named constants:
+
+```python
+HIGH_DEPENDENCY_THRESHOLD = 50
+MODERATE_DEPENDENCY_THRESHOLD = 25
+CRISIS_SEVERITY_THRESHOLD = 80
+```
+
+**Rules for thresholds**:
+- Define all numeric thresholds as module-level constants in `config.py`
+- Use semantic names (e.g., `HIGH_`, `MODERATE_`, `CRITICAL_`)
+- Document the threshold purpose with a comment
+- Use thresholds consistently across detectors
+- Thresholds should be tuned through eval suite assertions (see `evals/groups.json`)
+
+Example:
+
+```python
+# modules/config.py
+HIGH_DEPENDENCY_THRESHOLD = 50  # Score >= 50 triggers Dependency framework
+MODERATE_DEPENDENCY_THRESHOLD = 25  # Score >= 25 warrants dependency caution
+```
+
+## Secondary Scoring Patterns
+
+Some signals contribute partial scores. Use this pattern:
+
+```python
+score = 0
+signals_found = []
+
+# Pattern 1: Keyword match (low confidence)
+for pattern_name, pattern_regex in PATTERNS:
+    if pattern_regex.search(msg):
+        score += 10
+        signals_found.append(pattern_name)
+
+# Pattern 2: Semantic structure (medium confidence)
+if has_structure_x(msg):
+    score += 20
+    signals_found.append("structure_x_detected")
+
+# Pattern 3: Context from history (high confidence)
+if recent_messages_show_y():
+    score += 30
+    signals_found.append("context_confirms_signal")
+
+# Cap at 100
+score = min(score, 100)
+```
+
+**Rules**:
+- Combine multiple weak signals into a single higher confidence score
+- Later signals can amplify or override earlier ones
+- Always cap the final score at a reasonable maximum (typically 100)
+- Document the weighting rationale in code comments
+
+## Integration Methods
+
+### Framework Selector Integration
+
+Add your detector to the framework selection chain in `modules/framework_selector.py`:
+
+```python
+def select_framework(conversation_messages: list) -> str:
+    # ... existing priority checks ...
+    
+    # Your detector here
+    crisis_result = crisis_detector.analyze_crisis(conversation_messages)
+    if crisis_result["level"] == "TIER_1":
+        return "CRISIS"
+    
+    # Continue with other detectors
+```
+
+### CLI Tool Integration
+
+Detectors can be run standalone via CLI:
+
+```bash
+echo '{"messages": [...]}' | python3 -m modules.dependency_detector
+```
+
+This works automatically if your module follows the `if __name__ == "__main__"` pattern.
+
+### Test Integration
+
+Write unit tests in `tests/test_YOUR_detector.py`:
+
+```python
+def test_analyzer_detects_signal():
+    messages = [{"role": "user", "content": "only you understand me"}]
+    result = analyze_dependency(messages)
+    assert result["level"] == "HIGH"
+    assert "only_you_understand_me" in result["signals"]
+```
+
+## Pattern Definitions
+
+Detectors use regex patterns to identify signals. Store pattern definitions at module level:
+
+```python
+DEPENDENCY_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "only you understand me",
+        re.compile(r"\bonly you\s+(?:really\s+)?understand(?:s)?\s+me\b", re.IGNORECASE),
+    ),
+    (
+        "you're the only one",
+        re.compile(r"\byou(?:'re| are)\s+the\s+only\s+one\b", re.IGNORECASE),
+    ),
+]
+```
+
+**Rules**:
+- Use tuples of (name, compiled_pattern) for readability
+- Pre-compile regex patterns at module load time
+- Use `re.IGNORECASE` for case-insensitive matching
+- Document what each pattern detects
+- Keep patterns maintainable and not overly complex
+
+## Message Normalization
+
+Always normalize user messages before pattern matching:
+
+```python
+from modules.text_normalization import normalize_message_text
+
+for message in conversation_messages:
+    if message.get("role") == "user":
+        normalized = normalize_message_text(message["content"])
+        # Now search normalized message
+```
+
+This handles quote standardization and whitespace cleanup consistently across all detectors.
+
+## Testing and Validation
+
+### Unit Tests
+
+Write focused tests for each detector:
+
+```python
+def test_high_threshold():
+    # Input that should exceed high threshold
+    messages = [{"role": "user", "content": "..."}]
+    result = analyze_signal(messages)
+    assert result["score"] >= HIGH_THRESHOLD
+
+def test_no_signal():
+    # Input with no relevant signal
+    messages = [{"role": "user", "content": "What's the weather?"}]
+    result = analyze_signal(messages)
+    assert result["level"] == "NONE"
+```
+
+### Integration Tests
+
+Test your detector through the eval suite:
+
+1. Add test cases to `evals/groups.json` with `expect_primary_framework` set to the framework your detector selects
+2. Run `python3 -m soulmap_ai.tools.eval_groups` to validate
+3. Adjust thresholds if eval cases fail unexpectedly
+
+## Error Handling
+
+Detectors must handle malformed input gracefully:
+
+```python
+if not conversation_messages:
+    return {
+        "level": "NO_DATA",
+        "score": 0,
+        "signals": [],
+        "recommendation": "No messages to analyze."
+    }
+
+user_messages = [
+    m["content"] for m in conversation_messages
+    if isinstance(m, dict) and m.get("role") == "user"
+]
+
+if not user_messages:
+    return {
+        "level": "NO_DATA",
+        "score": 0,
+        "signals": [],
+        "recommendation": "No user messages found."
+    }
+```
+
+**Rules**:
+- Always return a valid result dict, never raise uncaught exceptions
+- Use `print_json_error()` for error messages to stdout
+- Return "NO_DATA" level when input is insufficient
+- Test edge cases: empty lists, malformed objects, missing fields

--- a/.claude/rules/evals-and-testing.md
+++ b/.claude/rules/evals-and-testing.md
@@ -1,0 +1,182 @@
+---
+paths:
+  - evals/groups.json
+  - evals/**/*.json
+  - tests/test_safety_evals.py
+---
+
+# Evals And Testing Rules
+
+Use these conventions when working with the evaluation suite and test groups.
+
+## Evals Directory Structure
+
+The `evals/` directory contains executable test case definitions:
+
+- `groups.json` - the master registry of eval groups and test cases
+- `*_cases.json` - source data files (selector_cases.json, response_cases.json, etc.)
+- `README.md` - documentation for running and extending evals
+
+`groups.json` is executable, not static config. Each change affects which assertions SoulMap must pass.
+
+## Group Structure
+
+Each group in `groups.json` has this schema:
+
+```json
+{
+  "g": "Human-readable group name",
+  "cat": "category short code (wl1, wl2, etc.)",
+  "sources": ["path/to/source1.md", "path/to/source2.md"],
+  "source_markers": {
+    "path/to/file.md": "quoted text or pattern from that file"
+  },
+  "items": [
+    {
+      "t": "test input text",
+      "note": "what this tests",
+      "expect_primary_framework": "FRAMEWORK_NAME",
+      "expect_mode": "MODE_NAME",
+      "expect_safety_status": "PASS",
+      "expect_safety_reason": "no_override"
+    }
+  ]
+}
+```
+
+**Required fields**:
+- `g` - group name (human-readable identifier)
+- `cat` - category code (lowercase, short)
+- `sources` - list of source files that justify this group's existence
+- `items` - array of test cases
+
+**Optional fields**:
+- `source_markers` - object mapping file paths to specific quoted text that backs this group
+
+## Adding New Groups
+
+When adding a new eval group:
+
+1. **Identify the category** - use an existing `cat` if applicable (wl1, wl2, etc.), or define a new one with clear intent
+2. **Name the group clearly** - the `g` field should state exactly what behavior is being tested
+3. **Document sources** - add paths to framework files, templates, or other documentation that justify the test cases
+4. **Use source_markers** - if a test case references specific text from a source file, add the mapping in `source_markers`
+5. **Keep items focused** - each item should test one clear assertion about framework selection or safety
+
+Example:
+
+```json
+{
+  "g": "Existential Framework - Life Direction Confusion",
+  "cat": "wl3",
+  "sources": [
+    "skills/frameworks/existential.md",
+    "templates/quick-reference.md"
+  ],
+  "source_markers": {
+    "templates/quick-reference.md": "I don't know what my life is for anymore"
+  },
+  "items": [
+    {
+      "t": "I don't know what my life is for anymore",
+      "note": "Core existential signal",
+      "expect_primary_framework": "EXISTENTIAL",
+      "expect_mode": "EXISTENTIAL",
+      "expect_safety_status": "PASS",
+      "expect_safety_reason": "no_override"
+    }
+  ]
+}
+```
+
+## Writing expect_primary_framework Assertions
+
+The `expect_primary_framework` field declares which framework SoulMap **must** use on this input.
+
+Valid framework names (from framework files in `skills/frameworks/`):
+- `MIRROR` - reflective mode (default)
+- `SANCTUARY` - high emotional intensity
+- `CRISIS` - Tier 1 crisis signals
+- `DEPENDENCY` - unhealthy AI dependency
+- `GRIEF` - acute grief signals
+- `DE_ESCALATION` - moderate emotional intensity
+- `EXISTENTIAL` - existential confusion
+- `INNER_PARTS` - inner conflict
+- `DIRECTION` - life direction confusion
+- `SHADOW` - shadow patterns
+- `INSIGHT` - integration moments
+- `SYNTHESIS` - theme synthesis on request
+
+**Rules for framework expectations**:
+- Each test case must have an `expect_primary_framework` that matches SoulMap's framework selection logic
+- Use the framework names exactly as defined in `skills/frameworks/`
+- Do not expect a framework that is lower priority than what the input would naturally trigger
+- If uncertain, set `expect_primary_framework: "MIRROR"` (the default)
+
+## Defining source_markers
+
+`source_markers` is an object that maps file paths to quoted text from those files. Use it to:
+
+- Document which specific language from source files backs a test case
+- Make it easy to trace why a particular eval group exists
+- Create audit trail for framework and safety decisions
+
+**How to use**:
+
+```json
+"source_markers": {
+  "skills/frameworks/grief.md": "acute loss, fresh grief, death of someone close",
+  "templates/quick-reference.md": "I just found out that..."
+}
+```
+
+The quotes should be verbatim from the source file (or close to it). If a test case is not backed by explicit source text, omit the marker for that file.
+
+## Running Evals
+
+Use the `eval_groups` tool or script to validate and run the eval suite:
+
+```bash
+python3 -m soulmap_ai.tools.eval_groups
+```
+
+This will:
+1. Parse `evals/groups.json` for syntax and schema validity
+2. Run each test case through the SoulMap framework detector
+3. Compare actual framework selection against expected frameworks
+4. Report pass/fail status and differences
+
+## Safety Assertions
+
+Each test case can include safety expectations:
+
+- `expect_safety_status`: `"PASS"` or `"OVERRIDE"` or `"BLOCK"`
+- `expect_safety_reason`: reason code (e.g., `"no_override"`, `"admin_override"`)
+
+These assertions validate that the safety detector is working as expected on the input.
+
+## Validation Errors
+
+Common issues when editing `groups.json`:
+
+| Error | Fix |
+|-------|-----|
+| Invalid JSON syntax | Check for missing commas, unclosed braces, trailing commas |
+| Unknown framework name | Verify the framework name matches a file in `skills/frameworks/` |
+| Missing required field | Ensure `g`, `cat`, `sources`, and `items` are present |
+| Duplicate category code | Use unique category codes or consolidate related groups |
+| Source file doesn't exist | Verify all paths in `sources` and `source_markers` are correct |
+
+## Testing Eval Groups
+
+After editing `groups.json`, run the test suite:
+
+```bash
+pytest tests/test_safety_evals.py -v
+```
+
+This validates that:
+- Your new groups conform to schema
+- All source files exist
+- All expected frameworks are recognized
+- Safety assertions are correctly specified

--- a/.claude/rules/evals-and-testing.md
+++ b/.claude/rules/evals-and-testing.md
@@ -13,15 +13,15 @@ Use these conventions when working with the evaluation suite and test groups.
 
 The `evals/` directory contains executable test case definitions:
 
-- `groups.json` - the master registry of eval groups and test cases
-- `*_cases.json` - source data files (selector_cases.json, response_cases.json, etc.)
+- `evals/groups.json` - the master registry of eval groups and test cases
+- individual case files (selector_cases.json, response_cases.json, etc.) - source data for specific eval suites
 - `README.md` - documentation for running and extending evals
 
-`groups.json` is executable, not static config. Each change affects which assertions SoulMap must pass.
+`evals/groups.json` is executable, not static config. Each change affects which assertions SoulMap must pass.
 
 ## Group Structure
 
-Each group in `groups.json` has this schema:
+Each group in `evals/groups.json` has this schema:
 
 ```json
 {
@@ -157,7 +157,7 @@ These assertions validate that the safety detector is working as expected on the
 
 ## Validation Errors
 
-Common issues when editing `groups.json`:
+Common issues when editing `evals/groups.json`:
 
 | Error | Fix |
 |-------|-----|
@@ -169,7 +169,7 @@ Common issues when editing `groups.json`:
 
 ## Testing Eval Groups
 
-After editing `groups.json`, run the test suite:
+After editing `evals/groups.json`, run the test suite:
 
 ```bash
 pytest tests/test_safety_evals.py -v

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -20,6 +20,12 @@ contract.
 - `operations-and-safety-review`
 - `release-readiness-review`
 
+## Product development skills
+
+- `detector-engineer` - write Python detectors for framework selection signals
+- `eval-suite-maintainer` - maintain evaluation test groups and assertions
+- `framework-author` - author new framework skill files
+
 ## Docs and content skills
 
 - `brand-copy-review`

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -22,9 +22,9 @@ contract.
 
 ## Product development skills
 
-- `detector-engineer` - write Python detectors for framework selection signals
-- `eval-suite-maintainer` - maintain evaluation test groups and assertions
-- `framework-author` - author new framework skill files
+- `detector-engineer`
+- `eval-suite-maintainer`
+- `framework-author`
 
 ## Docs and content skills
 

--- a/.claude/skills/detector-engineer/SKILL.md
+++ b/.claude/skills/detector-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: detector-engineer
-description: Develop and maintain Python detector modules that identify framework selection signals in conversation history.
+description: Build and maintain Python detector modules that identify framework selection signals in conversation history.
 ---
 
 # Detector Engineer
@@ -9,7 +9,7 @@ Use this skill when writing new detector modules, extending existing detectors, 
 
 ## Do not use this skill for
 
-- Editing rules and conventions - refer to `detector-development.md`
+- Editing rules and conventions - refer to [`.claude/rules/detector-development.md`](../../rules/detector-development.md)
 - Writing or extending test groups in evals/groups.json - use [`eval-suite-maintainer`](../eval-suite-maintainer/SKILL.md)
 - Defining framework activation signals - use [`framework-author`](../framework-author/SKILL.md)
 - General Python work outside modules/ - use code editing tools directly
@@ -338,6 +338,27 @@ for norm_msg in normalized_messages:
         if pattern.search(norm_msg):  # Fast lookup
             score += 10
 ```
+
+## Workflow
+
+1. Read `.claude/rules/detector-development.md` before writing any code.
+2. Check `modules/config/` for existing signal phrase constants to extend rather than duplicate.
+3. Write the detector following the anatomy and return value contract defined in this skill.
+4. Add threshold constants to `modules/config/safety.py` or the appropriate domain config.
+5. Integrate the detector call into `modules/framework_selector.py` at the correct priority.
+6. Add eval cases to `evals/groups.json` using [`eval-suite-maintainer`](../eval-suite-maintainer/SKILL.md).
+7. Run `python -m pytest -q` and `python -m tools.eval_groups` before pushing.
+
+## Definition Of Done
+
+A detector is done when:
+
+- It returns a dict matching the standard return value contract above
+- All signal constants live in `modules/config/` not inline in the function
+- It is called at the correct priority in `modules/framework_selector.py`
+- At least one eval case in `evals/groups.json` covers its primary signal
+- `python -m pytest -q` passes with no regressions
+- `python -m tools.eval_groups` passes for all groups it affects
 
 ## Relationship to Other Skills
 

--- a/.claude/skills/detector-engineer/SKILL.md
+++ b/.claude/skills/detector-engineer/SKILL.md
@@ -1,0 +1,346 @@
+---
+name: detector-engineer
+description: Develop and maintain Python detector modules that identify framework selection signals in conversation history.
+---
+
+# Detector Engineer
+
+Use this skill when writing new detector modules, extending existing detectors, or tuning detector thresholds based on eval results.
+
+## Do not use this skill for
+
+- Editing rules and conventions - refer to `detector-development.md`
+- Writing or extending test groups in evals/groups.json - use [`eval-suite-maintainer`](../eval-suite-maintainer/SKILL.md)
+- Defining framework activation signals - use [`framework-author`](../framework-author/SKILL.md)
+- General Python work outside modules/ - use code editing tools directly
+
+## Mission
+
+Detectors are the sensors in SoulMap's framework selection system. They analyze conversation history and score the presence of specific signals (crisis indicators, dependency language, existential confusion, etc.).
+
+This skill helps you:
+
+- Write new detector modules that follow established patterns
+- Use threshold constants correctly
+- Integrate detectors into the framework selector
+- Test detectors through the eval suite
+- Tune thresholds based on real test case results
+
+## Detector Anatomy
+
+Every detector has this structure:
+
+```python
+"""Score conversation history for signs of [signal]."""
+
+import json
+import sys
+from modules.cli_payload import read_stdin_json, print_json_error
+from modules.config import THRESHOLD_CONSTANTS
+
+def analyze_signal(conversation_messages: list) -> dict:
+    """Main scoring function."""
+    # Implementation
+    pass
+
+if __name__ == "__main__":
+    try:
+        payload = read_stdin_json()
+        result = analyze_signal(payload.get("messages", []))
+        print(json.dumps(result))
+    except Exception as e:
+        print_json_error(str(e))
+        sys.exit(1)
+```
+
+## Return Value Contract
+
+Every detector returns a standardized dict:
+
+```python
+{
+    "level": "HIGH",              # Signal level: TIER_1, HIGH, MODERATE, LOW, NONE, NO_DATA
+    "score": 75,                  # Numeric score (0-100 for consistency)
+    "signals": ["signal_name"],   # List of signal descriptions found
+    "recommendation": "..."       # Plain English recommendation
+}
+```
+
+**Levels**:
+- `TIER_1` - Highest severity (crisis, immediate danger)
+- `HIGH` - Strong signals requiring framework override
+- `MODERATE` - Notable signals worth attention
+- `LOW` - Weak signals, may be context-dependent
+- `NONE` - No signals found
+- `NO_DATA` - Insufficient input to analyze
+
+## Signal Detection Patterns
+
+### Pattern 1: Keyword and Regex Matching
+
+Use pre-compiled regex patterns defined at module level:
+
+```python
+SIGNAL_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("signal_name", re.compile(r"pattern here", re.IGNORECASE)),
+    ("another_signal", re.compile(r"another pattern", re.IGNORECASE)),
+]
+
+# In analyze function:
+for pattern_name, pattern_regex in SIGNAL_PATTERNS:
+    if pattern_regex.search(normalized_message):
+        score += 10
+        signals_found.append(pattern_name)
+```
+
+**Rules**:
+- Pre-compile patterns at module load (not in functions)
+- Use descriptive names for each pattern
+- Use `re.IGNORECASE` for human input matching
+- Store as tuple of (name, compiled_pattern)
+
+### Pattern 2: Semantic Structure Analysis
+
+Detect patterns in sentence structure or word order:
+
+```python
+def has_dependency_language(msg: str) -> bool:
+    """Check for exclusive reliance language."""
+    markers = ["only you", "no one else", "can't talk to anyone"]
+    return any(marker in msg.lower() for marker in markers)
+
+if has_dependency_language(msg):
+    score += 20
+    signals_found.append("exclusive_reliance")
+```
+
+### Pattern 3: Conversation History Context
+
+Use recent message context to amplify confidence:
+
+```python
+def recent_messages_show_pattern(messages: list) -> bool:
+    """Check last 3 messages for consistent pattern."""
+    user_messages = [m["content"] for m in messages[-3:] if m.get("role") == "user"]
+    return len([m for m in user_messages if has_signal(m)]) >= 2
+
+if recent_messages_show_pattern(messages):
+    score += 30
+    signals_found.append("pattern_in_history")
+```
+
+## Threshold Management
+
+Thresholds define when a detector's score triggers a framework override.
+
+### Define Thresholds in config.py
+
+```python
+# modules/config.py
+HIGH_DEPENDENCY_THRESHOLD = 50      # Score >= 50 triggers Dependency framework
+MODERATE_DEPENDENCY_THRESHOLD = 25  # Score >= 25 warrants caution
+CRISIS_SEVERITY_THRESHOLD = 80      # Tier 1 crisis score
+```
+
+### Use Thresholds Consistently
+
+```python
+from modules.config import HIGH_DEPENDENCY_THRESHOLD
+
+if score >= HIGH_DEPENDENCY_THRESHOLD:
+    level = "HIGH"
+elif score > 0:
+    level = "MODERATE"
+else:
+    level = "NONE"
+```
+
+### Tune Thresholds Based on Evals
+
+1. Run `python3 -m soulmap_ai.tools.eval_groups` to see which tests fail
+2. If detector scores are too high/low, adjust the threshold in `config.py`
+3. Re-run evals to verify the fix
+4. Document threshold rationale in comments
+
+Example adjustment:
+
+```python
+# Before: threshold too high, missing moderate dependency cases
+HIGH_DEPENDENCY_THRESHOLD = 75  # Changed from 75 to 50
+# Now: threshold captures high-confidence dependency signals
+HIGH_DEPENDENCY_THRESHOLD = 50
+```
+
+## Scoring Best Practices
+
+### Combine Multiple Signals
+
+Don't rely on a single keyword. Combine patterns:
+
+```python
+score = 0
+
+# Weak signal: keyword match
+if keyword_found:
+    score += 10
+
+# Medium signal: semantic structure
+if structure_matches:
+    score += 20
+
+# Strong signal: confirmed by history
+if history_confirms:
+    score += 30
+
+score = min(score, 100)  # Cap at 100
+```
+
+### Handle Edge Cases
+
+```python
+# No input
+if not messages:
+    return {"level": "NO_DATA", "score": 0, "signals": [], "recommendation": "..."}
+
+# Empty user messages
+user_messages = [m["content"] for m in messages if m.get("role") == "user"]
+if not user_messages:
+    return {"level": "NO_DATA", "score": 0, "signals": [], "recommendation": "..."}
+
+# Malformed entries
+for msg in messages:
+    if not isinstance(msg, dict) or "content" not in msg:
+        continue
+```
+
+## Integration with Framework Selector
+
+Your detector integrates here in `modules/framework_selector.py`:
+
+```python
+from modules import your_detector
+
+def select_framework(messages: list) -> str:
+    # ... crisis check first (highest priority) ...
+    
+    # Your detector
+    result = your_detector.analyze_signal(messages)
+    if result["level"] == "HIGH":
+        return "YOUR_FRAMEWORK"
+    
+    # ... continue with other detectors ...
+```
+
+**Rules**:
+- Check detectors in priority order (defined in AGENTS.md Section 2)
+- Higher-priority signals always override lower-priority ones
+- Each detector should handle its own edge cases gracefully
+
+## Testing Your Detector
+
+### Unit Tests
+
+```python
+# tests/test_your_detector.py
+from modules import your_detector
+
+def test_detects_signal():
+    messages = [{"role": "user", "content": "[signal text here]"}]
+    result = your_detector.analyze_signal(messages)
+    assert result["level"] == "HIGH"
+    assert "expected_signal_name" in result["signals"]
+
+def test_no_false_positives():
+    messages = [{"role": "user", "content": "What's the weather?"}]
+    result = your_detector.analyze_signal(messages)
+    assert result["level"] == "NONE"
+
+def test_no_data():
+    result = your_detector.analyze_signal([])
+    assert result["level"] == "NO_DATA"
+```
+
+### Integration Tests via Evals
+
+Add test cases to `evals/groups.json` that should trigger your detector:
+
+```json
+{
+  "g": "Your Framework - Core Signal",
+  "cat": "your_cat",
+  "sources": ["skills/frameworks/your_framework.md"],
+  "items": [
+    {
+      "t": "input that triggers your detector",
+      "expect_primary_framework": "YOUR_FRAMEWORK"
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+python3 -m soulmap_ai.tools.eval_groups
+```
+
+Verify your detector's test cases pass.
+
+## Message Normalization
+
+Always normalize messages before pattern matching:
+
+```python
+from modules.text_normalization import normalize_message_text
+
+for msg in user_messages:
+    normalized = normalize_message_text(msg)
+    # Now search normalized message for patterns
+    if pattern.search(normalized):
+        score += 10
+```
+
+This ensures consistent handling of quotes, whitespace, and common text variations.
+
+## CLI Testing
+
+Test your detector from the command line:
+
+```bash
+echo '{"messages": [{"role": "user", "content": "test input"}]}' | python3 -m modules.your_detector
+```
+
+Expected output:
+
+```json
+{
+  "level": "HIGH",
+  "score": 75,
+  "signals": ["signal_name"],
+  "recommendation": "..."
+}
+```
+
+## Performance Considerations
+
+- Pre-compile regex patterns (do not recompile in loops)
+- Use efficient string operations (`.lower()` once, not per pattern)
+- Limit history analysis to recent messages (last 10, not entire history)
+- Avoid expensive operations in scoring loops
+
+Example:
+
+```python
+# Good: normalize once
+normalized_messages = [normalize_message_text(m) for m in user_messages]
+for norm_msg in normalized_messages:
+    for pattern_name, pattern in PATTERNS:
+        if pattern.search(norm_msg):  # Fast lookup
+            score += 10
+```
+
+## Relationship to Other Skills
+
+- **framework-author** defines what signals activate a framework → you implement detectors to identify those signals
+- **eval-suite-maintainer** writes test cases → you tune your detector to pass those tests
+- **research-and-gap-analysis** finds missing signals → you implement detectors to address those gaps

--- a/.claude/skills/eval-suite-maintainer/SKILL.md
+++ b/.claude/skills/eval-suite-maintainer/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: eval-suite-maintainer
+description: Maintain the evaluation suite by managing test groups, writing assertions, and validating framework decisions through evals/groups.json.
+---
+
+# Eval Suite Maintainer
+
+Use this skill when working with the evaluation suite infrastructure-adding test cases, writing framework assertions, validating source markers, and running eval results.
+
+## Do not use this skill for
+
+- Modifying the core framework selection logic - use code editing tools directly and follow `detector-development.md`
+- Writing framework skill files (Activation Signals, Response Structure) - use [`framework-author`](../framework-author/SKILL.md)
+- Developing new detector modules - use [`detector-engineer`](../detector-engineer/SKILL.md)
+- Creating non-eval tests - use standard pytest patterns
+
+## Mission
+
+The eval suite (`evals/groups.json`) is the single source of truth for what behavior SoulMap must exhibit. This skill maintains that source of truth by:
+
+- Adding new test groups that represent real user inputs
+- Writing clear framework expectations backed by source documentation
+- Ensuring test cases trace back to framework documentation
+- Validating that eval results pass before merging changes
+
+## What Is evals/groups.json?
+
+`evals/groups.json` is not configuration. It is executable specification.
+
+Each group is a cluster of related test cases. Each item tests whether SoulMap:
+1. Selects the correct primary framework for that input
+2. Passes safety checks with the expected status and reason
+
+The group structure guarantees that:
+- Every test case is backed by a source file (framework skill, template, or other documentation)
+- Test cases can be traced back to the language that inspired them
+- Framework selection decisions are auditable
+
+## Sources Of Truth
+
+Always check these files first:
+
+- `evals/README.md` - how to run evals and interpret results
+- `.claude/rules/evals-and-testing.md` - group structure conventions and schema
+- `skills/frameworks/` - the authoritative framework definitions
+- `evals/groups.json` - the current eval state
+
+## When To Add A Test Group
+
+Add a new group to `evals/groups.json` when:
+
+- A framework file has been updated or created and needs test coverage
+- A new template or quick-reference entry has been added
+- You discover a real user input that should trigger a specific framework
+- A framework selection decision needs to be auditable (via source markers)
+
+Do NOT add a group just to test code-use `tests/` for that.
+
+## Structure Of A Test Group
+
+```json
+{
+  "g": "Human-readable group name describing what is tested",
+  "cat": "short category code (wl1, wl2, crisis, etc.)",
+  "sources": [
+    "skills/frameworks/mirror.md",
+    "templates/quick-reference.md"
+  ],
+  "source_markers": {
+    "templates/quick-reference.md": "quoted text from that file"
+  },
+  "items": [
+    {
+      "t": "test input text",
+      "note": "what this tests and why",
+      "expect_primary_framework": "MIRROR",
+      "expect_mode": "MIRROR",
+      "expect_safety_status": "PASS",
+      "expect_safety_reason": "no_override"
+    }
+  ]
+}
+```
+
+**Required fields**:
+- `g` - group name (clear, human-readable)
+- `cat` - category code (consistent across related groups)
+- `sources` - list of documentation files that justify this group
+- `items` - array of test cases
+
+**Optional fields**:
+- `source_markers` - object mapping file paths to specific quoted text
+
+## Writing expect_primary_framework Assertions
+
+The `expect_primary_framework` field is the contract: SoulMap MUST select this framework for this input.
+
+**Valid framework names**:
+- `MIRROR` - reflective mode (default)
+- `SANCTUARY` - high emotional intensity
+- `CRISIS` - Tier 1 crisis signals
+- `DEPENDENCY` - unhealthy AI dependency
+- `GRIEF` - acute grief signals
+- `DE_ESCALATION` - moderate emotional intensity
+- `EXISTENTIAL` - existential confusion
+- `INNER_PARTS` - inner conflict
+- `DIRECTION` - life direction confusion
+- `SHADOW` - shadow patterns
+- `INSIGHT` - integration moments
+- `SYNTHESIS` - theme synthesis on request
+
+**Rules**:
+- Match the framework name exactly to the file in `skills/frameworks/`
+- Use uppercase names (e.g., `CRISIS`, not `Crisis`)
+- If uncertain, use `MIRROR` (the default)
+- Do not expect a framework lower priority than what the input naturally triggers
+- Reference the framework file's priority in comments if it helps explain the choice
+
+Example:
+
+```json
+{
+  "t": "I just found out my mother died",
+  "note": "Acute loss - triggers Grief (higher priority than Mirror)",
+  "expect_primary_framework": "GRIEF",
+  "expect_mode": "GRIEF",
+  "expect_safety_status": "PASS",
+  "expect_safety_reason": "no_override"
+}
+```
+
+## Defining source_markers
+
+Use `source_markers` to create an audit trail. Map file paths to direct quotes from those files.
+
+```json
+"source_markers": {
+  "skills/frameworks/grief.md": "acute loss, fresh grief",
+  "templates/quick-reference.md": "I just found out..."
+}
+```
+
+**Rules**:
+- Include quotes verbatim (or very close) from source files
+- Use markers only for test cases backed by explicit source text
+- Omit markers if a test case is general (not tied to specific language)
+- Update markers if the source file language changes
+
+## Running and Validating Evals
+
+### Check eval status
+
+```bash
+python3 -m soulmap_ai.tools.eval_groups
+```
+
+This validates schema and runs all test cases, reporting:
+- Pass/fail for each test case
+- Actual framework vs. expected framework
+- Safety assertion results
+
+### Interpret Results
+
+| Result | Meaning |
+|--------|---------|
+| ✅ PASS | Framework selection and safety match expectations |
+| ❌ FAIL | Actual result differs from expected (framework, safety, etc.) |
+| ⚠️ SCHEMA ERROR | JSON structure or invalid framework name |
+
+### Debug Failures
+
+If a test case fails:
+
+1. **Check the assertion**: Is `expect_primary_framework` correct? Does it match the framework file name?
+2. **Check the source**: Are the source files listed in `sources` actually there?
+3. **Check the input**: Is the test input clear? Does it trigger the expected framework?
+4. **Verify framework logic**: Has the framework file been updated recently? Does its activation logic still match?
+
+## Adding Multiple Related Test Cases
+
+When you add a new framework or template section, add multiple test cases covering different activation scenarios:
+
+```json
+{
+  "g": "New Framework - Scenario A",
+  "cat": "new",
+  "sources": ["skills/frameworks/new-framework.md"],
+  "items": [
+    {"t": "input that triggers scenario A", "expect_primary_framework": "NEW_FRAMEWORK"},
+    {"t": "input that triggers scenario B", "expect_primary_framework": "NEW_FRAMEWORK"},
+    {"t": "edge case input", "expect_primary_framework": "NEW_FRAMEWORK"}
+  ]
+}
+```
+
+This ensures coverage and makes it easier to debug if the framework selection logic changes.
+
+## Syntax and Validation
+
+### Common Errors
+
+| Error | Fix |
+|-------|-----|
+| JSON parse error | Check for missing commas, unclosed braces, trailing commas after last item |
+| Unknown framework | Verify framework name matches `skills/frameworks/FRAMEWORK_NAME.md` exactly |
+| Missing required field | Ensure `g`, `cat`, `sources`, `items` are all present |
+| File path doesn't exist | Verify all paths in `sources` and `source_markers` exist in the repo |
+| Duplicate `cat` | If consolidating groups, use the same category code for related tests |
+
+### Validate Locally
+
+After editing `evals/groups.json`:
+
+```bash
+# Quick JSON check
+python3 -c "import json; json.load(open('evals/groups.json'))"
+
+# Run full eval suite
+python3 -m soulmap_ai.tools.eval_groups
+
+# Run unit tests
+pytest tests/test_safety_evals.py -v
+```
+
+## Best Practices
+
+1. **One assertion per test case** - keep test cases focused; each should test one clear decision
+2. **Use clear test text** - inputs should be realistic and representative of real user language
+3. **Document with notes** - explain why each test case matters in the `note` field
+4. **Source everything** - if you add a test case, it should be backed by a source file
+5. **Run evals before committing** - verify all tests pass before merging
+6. **Keep groups related** - group similar test cases under the same `g` and `cat`
+
+## Relationship to Other Skills
+
+- **detector-engineer** writes the code that SoulMap uses to detect signals → you write evals to validate that code
+- **framework-author** defines framework activation signals → you reference those files in `sources` and write test cases for them
+- **research-and-gap-analysis** finds gaps in the test suite → you implement the fixes via this skill

--- a/.claude/skills/eval-suite-maintainer/SKILL.md
+++ b/.claude/skills/eval-suite-maintainer/SKILL.md
@@ -9,7 +9,7 @@ Use this skill when working with the evaluation suite infrastructure-adding test
 
 ## Do not use this skill for
 
-- Modifying the core framework selection logic - use code editing tools directly and follow `detector-development.md`
+- Modifying the core framework selection logic - use code editing tools directly and follow [`.claude/rules/detector-development.md`](../../rules/detector-development.md)
 - Writing framework skill files (Activation Signals, Response Structure) - use [`framework-author`](../framework-author/SKILL.md)
 - Developing new detector modules - use [`detector-engineer`](../detector-engineer/SKILL.md)
 - Creating non-eval tests - use standard pytest patterns
@@ -230,6 +230,26 @@ pytest tests/test_safety_evals.py -v
 4. **Source everything** - if you add a test case, it should be backed by a source file
 5. **Run evals before committing** - verify all tests pass before merging
 6. **Keep groups related** - group similar test cases under the same `g` and `cat`
+
+## Workflow
+
+1. Read `evals/README.md` to understand the current eval suite structure.
+2. Identify the framework or safety behavior the new group is testing.
+3. Find the source files (in `skills/` or `templates/`) that justify the test cases.
+4. Write the group following the structure defined in this skill.
+5. Add `source_markers` for high-confidence slices that reference specific policy text.
+6. Run `python -m tools.eval_groups` and verify no existing assertions broke.
+7. Run `python -m pytest -q` before committing.
+
+## Definition Of Done
+
+An eval group is done when:
+
+- All items have a `note` field describing what is being tested
+- All asserted items have expectations backed by real source files in `sources`
+- `source_markers` are present for any high-risk or safety-critical slice
+- `python -m tools.eval_groups` passes for the new group
+- `python -m pytest -q` passes with no regressions
 
 ## Relationship to Other Skills
 

--- a/.claude/skills/framework-author/SKILL.md
+++ b/.claude/skills/framework-author/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: framework-author
+description: Write and maintain framework skill files that define activation signals and response structures for SoulMap's framework system.
+---
+
+# Framework Author
+
+Use this skill when creating new frameworks or substantially updating existing framework skill files.
+
+## Do not use this skill for
+
+- Implementing detectors that identify frameworks - use [`detector-engineer`](../detector-engineer/SKILL.md)
+- Writing eval test cases for frameworks - use [`eval-suite-maintainer`](../eval-suite-maintainer/SKILL.md)
+- General documentation editing - use [`docs-and-api-writer`](../docs-and-api-writer/SKILL.md)
+- Creating non-framework skill files under `skills/` - reference those in `skills/meta/` instead
+
+## Mission
+
+Framework skill files live in `skills/frameworks/` and define:
+
+1. **When a framework activates** - Activation Signals section
+2. **How to respond** - Response Structure section
+3. **Key concepts** - context and framing for users of the framework
+
+This skill helps you author frameworks that are:
+
+- Internally consistent and clear
+- Properly integrated with the detector system
+- Testable through the eval suite
+- Referenced correctly by source markers in eval groups
+
+## Framework File Location
+
+New frameworks live here:
+
+```
+skills/frameworks/{framework-name}.md
+```
+
+Examples:
+- `skills/frameworks/mirror.md` - reflective mode
+- `skills/frameworks/crisis.md` - crisis response
+- `skills/frameworks/grief.md` - grief support
+
+## YAML Frontmatter
+
+Every framework file starts with metadata:
+
+```yaml
+---
+name: "framework-name"
+description: "One-line description of what this framework does"
+---
+```
+
+Examples:
+
+```yaml
+---
+name: "crisis"
+description: "Safety-first response when user signals Tier 1 crisis (self-harm, suicidal ideation, abuse)"
+---
+```
+
+```yaml
+---
+name: "self-compassion"
+description: "Self-compassion language for shame, self-criticism, and the inner critic"
+---
+```
+
+## Required Sections
+
+Every framework must have these sections:
+
+### Activation Signals
+
+Clearly describe what user language or situation triggers this framework.
+
+```markdown
+## When to Activate This Framework
+
+Signals:
+
+- "I don't know who I really am"
+- "Nothing I do feels authentic"
+- "I'm just pretending to be someone"
+- User expressing identity instability or feeling like a "mask"
+```
+
+**Rules**:
+- Use first-person language ("I" statements from the user)
+- Be specific - give examples, not just categories
+- Include what NOT to confuse this with (if relevant)
+- Keep the signal list concise (5-10 examples, not exhaustive)
+
+### Response Structure
+
+Explain the structure SoulMap uses when this framework activates.
+
+```markdown
+## Response Structure
+
+1. **Acknowledge** - name the experience without judgment
+2. **Explore** - ask what the identity question is really about
+3. **Normalize** - this is part of human development, not pathology
+4. **Inquiry** - one open question that turns the user inward
+```
+
+**Rules**:
+- Number or bullet the steps
+- Include a brief description of each step
+- Show how this differs from other frameworks (if applicable)
+- Keep it concise (2-4 steps typically)
+
+### Key Concepts
+
+Explain foundational ideas used in this framework.
+
+```markdown
+## Key Concepts
+
+**Authentic Self vs. Performed Self** - humans adapt to contexts. The question isn't which is "real," 
+but whether the user can access their own knowing across contexts.
+
+**Identity Development** - identity isn't static. Uncertainty about values or purpose is often a sign 
+of growth, not collapse.
+```
+
+**Rules**:
+- Define concepts that might be unfamiliar
+- Use bold for concept names
+- Keep definitions accessible (not jargon-heavy)
+- Limit to 2-4 key concepts
+
+### Practical Reflection Language
+
+Show examples of how to communicate this framework to users.
+
+```markdown
+## Practical Reflection Language
+
+**Opening lines:**
+- "There's a difference between not knowing who you are and not being able to access who you are right now."
+- "Something in what you just said feels exploratory, not lost."
+
+**Reflective questions:**
+- "When you imagine being fully yourself, what's present?"
+- "Who are you when no one's watching?"
+
+**What not to do:**
+- Don't tell them who they are
+- Don't minimize their confusion
+- Don't offer reassurance ("You're fine, just confused")
+```
+
+**Rules**:
+- Use actual language, not abstract descriptions
+- Include examples of what NOT to say
+- Show conversational tone
+- Make it applicable to real user inputs
+
+### What Not to Do (if relevant)
+
+Explain common mistakes or framework misuse.
+
+```markdown
+## What Not to Do
+
+- **Don't rush to interpretation** - "I'm confused about my identity" isn't yet a clear signal. Let the user describe more first.
+- **Don't dismiss the confusion** - "This is just a phase" minimizes real exploration.
+- **Don't offer certainty** - "Your values are actually X" centers the wrong person's authority.
+```
+
+## Optional Sections
+
+Frameworks may also include:
+
+- **Relationship to Other Frameworks** - how this differs from similar frameworks
+- **Common Variations** - different ways the signal appears in real conversation
+- **Integration with Inner Parts Work** - if this framework relates to inner parts language
+- **Ethical Boundaries** - where this framework does and doesn't apply
+
+Example:
+
+```markdown
+## Relationship to Other Frameworks
+
+**MIRROR** - our default. Use MIRROR when the user is exploring openly. Use DIRECTION when the 
+exploration feels specifically about life purpose or path.
+
+**INNER_PARTS** - some identity confusion involves conflicting inner voices. But if the user isn't 
+describing internal conflict (just uncertainty), stay with DIRECTION rather than shifting to inner parts.
+```
+
+## Framework Integration
+
+### Register in Detector System
+
+Your framework needs a detector that identifies when to activate it. After writing the framework file:
+
+1. Create or update a detector in `modules/your_framework_detector.py`
+2. Add it to the framework selector in `modules/framework_selector.py`
+3. Reference it from `detector-engineer` skill if creating new detector patterns
+
+### Add Test Coverage
+
+Create eval test cases in `evals/groups.json`:
+
+```json
+{
+  "g": "Your Framework - Core Signal",
+  "cat": "your_cat",
+  "sources": [
+    "skills/frameworks/your_framework.md",
+    "templates/quick-reference.md"
+  ],
+  "source_markers": {
+    "skills/frameworks/your_framework.md": "Signal from 'Activation Signals' section"
+  },
+  "items": [
+    {
+      "t": "user input that triggers your framework",
+      "note": "Testing core signal",
+      "expect_primary_framework": "YOUR_FRAMEWORK_NAME",
+      "expect_mode": "YOUR_FRAMEWORK_NAME",
+      "expect_safety_status": "PASS",
+      "expect_safety_reason": "no_override"
+    }
+  ]
+}
+```
+
+### Update Quick Reference (if applicable)
+
+If the framework should appear in `templates/quick-reference.md`, add an entry:
+
+```markdown
+| Your Framework | Signal | Example |
+|---|---|---|
+| Your Framework | User describes [signal] | "I don't know what my life is for" |
+```
+
+## Writing Quality Standards
+
+### Clarity
+
+- Use concrete examples, not abstract concepts
+- Keep sentences short and direct
+- Avoid clinical language unless it's the framework's voice
+- Define any specialized terms
+
+### Consistency
+
+- Match the tone of existing frameworks (`skills/frameworks/`)
+- Use the same YAML frontmatter format
+- Follow the section structure (Signals, Response, Concepts, Language, What Not To Do)
+- Reference other frameworks using backticks and relative paths
+
+### Completeness
+
+- Activation signals are specific and traceable
+- Response structure is clear and actionable
+- Examples of what to say and what not to say
+- Framework name appears in YAML, headings, and discussions
+
+### Auditability
+
+- Each framework should be testable through `evals/groups.json`
+- Concepts should trace back to SoulMap's brand doctrine (`AGENTS.md`)
+- Language examples should be realistic and gender/culture-neutral
+
+## Example Framework Template
+
+Use this as a starting point:
+
+```markdown
+---
+name: "framework-name"
+description: "One-line description of what this framework does"
+---
+
+# Framework Name
+
+Brief intro explaining the framework's purpose.
+
+## When to Activate This Framework
+
+Signals:
+
+- "Example signal 1"
+- "Example signal 2"
+- "Example signal 3"
+- User describing [specific condition]
+
+## Response Structure
+
+1. **Step 1** - Brief description
+2. **Step 2** - Brief description
+3. **Step 3** - Brief description
+4. **Step 4** - Brief description
+
+## Key Concepts
+
+**Concept 1** - Definition and context.
+
+**Concept 2** - Definition and context.
+
+## Practical Reflection Language
+
+**Opening lines:**
+- "Quote that opens with this framework"
+- "Another opening approach"
+
+**Reflective questions:**
+- "Question 1"
+- "Question 2"
+
+**What not to do:**
+- Don't do this (and why)
+- Don't do that (and why)
+
+## Relationship to Other Frameworks
+
+**FRAMEWORK_A** - How this differs.
+
+**FRAMEWORK_B** - How this differs.
+```
+
+## Testing Your Framework
+
+### Schema Check
+
+Ensure YAML frontmatter is valid:
+
+```bash
+python3 -c "import yaml; yaml.safe_load(open('skills/frameworks/your_framework.md'))"
+```
+
+### Run Evals
+
+After adding test cases to `evals/groups.json`:
+
+```bash
+python3 -m soulmap_ai.tools.eval_groups
+```
+
+Verify all test cases for your framework pass.
+
+### Manual Review
+
+Have another contributor review:
+- Clarity of activation signals
+- Practical applicability of response structure
+- Quality of reflection language examples
+- Consistency with other frameworks
+
+## Naming Conventions
+
+- Framework file name: lowercase with hyphens (`skills/frameworks/framework-name.md`)
+- Framework constant name: uppercase with underscores (`FRAMEWORK_NAME`)
+- Category code in evals: short, memorable (`wl1`, `crisis`, `existential`)
+
+Examples:
+
+| File | Constant | Category |
+|------|----------|----------|
+| `inner-parts.md` | `INNER_PARTS` | `wl6` |
+| `shadow-patterns.md` | `SHADOW` | `wl8` |
+| `crisis.md` | `CRISIS` | `crisis` |
+
+## Relationship to Other Skills
+
+- **detector-engineer** implements the code that detects when this framework should activate
+- **eval-suite-maintainer** writes test cases that validate your framework works correctly
+- **research-and-gap-analysis** identifies which frameworks are missing or need updating

--- a/.claude/skills/framework-author/SKILL.md
+++ b/.claude/skills/framework-author/SKILL.md
@@ -31,12 +31,12 @@ This skill helps you author frameworks that are:
 
 ## Framework File Location
 
-New frameworks live here: `skills/frameworks/{framework-name}.md`
+New frameworks live here: `skills/frameworks/` (use kebab-case filename matching the framework name).
 
 Examples:
-- `skills/frameworks/mirror.md` - reflective mode
-- `skills/frameworks/crisis.md` - crisis response
-- `skills/frameworks/grief.md` - grief support
+- `skills/frameworks/emotional-deescalation.md` - crisis and de-escalation response
+- `skills/frameworks/grief-companion.md` - grief support
+- `skills/frameworks/inner-parts.md` - inner conflict work
 
 ## YAML Frontmatter
 
@@ -364,6 +364,29 @@ Examples:
 | `inner-parts.md` | `INNER_PARTS` | `wl6` |
 | `shadow-patterns.md` | `SHADOW` | `wl8` |
 | `crisis.md` | `CRISIS` | `crisis` |
+
+## Workflow
+
+1. Read `AGENTS.md` Section 2 (Framework Selection) to verify priority placement.
+2. Read an existing framework file in `skills/frameworks/` for structural reference.
+3. Create the new file under `skills/frameworks/` with the required sections.
+4. Add the framework to the priority hierarchy in `skills/meta/orchestration.md`.
+5. Add the framework to `skills/meta/framework-template-map.md`.
+6. Work with [`detector-engineer`](../detector-engineer/SKILL.md) to implement the detector.
+7. Work with [`eval-suite-maintainer`](../eval-suite-maintainer/SKILL.md) to add eval coverage.
+8. Run `python -m tools.build_skill` and `python -m pytest -q` before committing.
+
+## Definition Of Done
+
+A framework file is done when:
+
+- YAML frontmatter has a valid `name` matching the filename stem
+- `## Activation Signals` section is present with observable detection language
+- `## Response Structure` section defines the arc and word count range
+- `## Paired template` section references the correct template and inquiry bank section
+- A corresponding detector exists in `modules/` or is planned
+- At least one eval group in `evals/groups.json` covers the primary activation signal
+- `python -m tools.build_skill` includes the new file without error
 
 ## Relationship to Other Skills
 

--- a/.claude/skills/framework-author/SKILL.md
+++ b/.claude/skills/framework-author/SKILL.md
@@ -31,11 +31,7 @@ This skill helps you author frameworks that are:
 
 ## Framework File Location
 
-New frameworks live here:
-
-```
-skills/frameworks/{framework-name}.md
-```
+New frameworks live here: `skills/frameworks/{framework-name}.md`
 
 Examples:
 - `skills/frameworks/mirror.md` - reflective mode


### PR DESCRIPTION
Add comprehensive documentation for SoulMap AI development workflows:

- evals-and-testing.md: Conventions for eval suite management, test groups, framework assertions, and source_marker usage
- detector-development.md: Patterns for Python detector modules, scoring conventions, threshold management, and integration methods
- eval-suite-maintainer skill: Guidance for maintaining evaluation suite
- detector-engineer skill: Guidance for developing detector modules
- framework-author skill: Guidance for authoring framework skill files
- post-edit-evals.sh hook: Automation for evals/groups.json validation

All files follow .claude/ conventions and pass markdown contract validation.

Resolves documentation gaps for project expansion scope.