### PR TITLE
docs(upload): rewrite AI tool compatibility with accurate ZIP and ski…

### DIFF
--- a/docs/UPLOAD.md
+++ b/docs/UPLOAD.md
@@ -29,15 +29,41 @@ Treat `.claude-plugin/` as opaque metadata during packaging and upload. Do not e
 
 ## AI tool compatibility
 
-**ChatGPT:** ChatGPT's official docs describe uploads for common file types and project reference material such as PDFs, spreadsheets, docs, images, and pasted text. They do not explicitly document `.zip` or `.skill` as first-class upload formats, so the safest workflow is to extract the archive first and upload the Markdown or text files you want it to use.
+### ChatGPT
 
-**Claude:** Claude's official upload docs cover standard document types, and Anthropic's Skills docs describe custom Skills as ZIP-based packages containing a `SKILL.md` file. For Claude, use the extracted knowledge files for normal document uploads, and use a ZIP-based skill package only in workflows that explicitly support Claude Skills.
+ChatGPT handles ZIP files differently depending on the context you are working in.
 
-**Any Agent Skills-compatible agent:** Agent Skills are an open format built around a portable skill folder with `SKILL.md` at the root, so the `.skill` archive should be treated as a transport package that can be unpacked into that directory structure.
+**Conversations (Plus/Pro with Code Interpreter enabled):** You can upload a ZIP file directly and ChatGPT will extract and read its contents using the Code Interpreter sandbox. This makes the standard `dist/soulmap-ai.zip` usable as a multi-file upload in a single step - upload the archive, then ask ChatGPT to read `SKILL.md`, `AGENTS.md`, and the relevant folders under `skills/` and `templates/`.
+
+**Custom GPT knowledge base:** ZIP files are not supported as Custom GPT knowledge files. OpenAI's knowledge retrieval system indexes individual text-based documents (PDF, DOCX, TXT, Markdown). For a Custom GPT, extract the archive and upload the individual Markdown and text files you want indexed.
+
+**Recommended workflow for Custom GPT:**
+
+1. Extract `dist/soulmap-ai.zip`.
+2. Upload `SKILL.md`, `AGENTS.md`, and the key files under `skills/` and `templates/`.
+3. Keep each file under 512 MB and prefer plain Markdown or TXT for reliable retrieval.
+
+### Claude
+
+Claude handles ZIP files only via the Custom Skills feature, not as regular document uploads.
+
+**Custom Skills (Pro, Max, Team, Enterprise - requires Code Execution enabled):** Claude's official Skills system accepts ZIP archives through `Customize > Skills > Upload a skill`. The archive must contain a `SKILL.md` at the root. The `dist/soulmap-ai.skill` file follows exactly this structure and can be uploaded directly - rename it to `.zip` first if the upload dialog requires a `.zip` extension.
+
+**Claude.ai conversations and Project knowledge:** ZIP files are not supported as regular uploads. Claude accepts PDF, DOCX, TXT, RTF, HTML, CSV, Markdown, and images up to 30 MB per file. For Project knowledge, upload the individual extracted files.
+
+**Recommended workflow for Claude Projects:**
+
+1. Extract `dist/soulmap-ai.zip`.
+2. Upload `SKILL.md`, `AGENTS.md`, and the relevant files under `skills/` and `templates/` to the Project knowledge base.
+3. For the full Custom Skills experience, upload `dist/soulmap-ai.skill` (or rename to `.zip`) via `Customize > Skills`.
+
+### Any Agent Skills-compatible agent
+
+Agent Skills are an open format built around a portable skill folder with `SKILL.md` at the root. The `.skill` archive is a transport package that can be unpacked into that directory structure on any compatible agent runtime.
 
 ## Standard build examples
 
-### Zip example for ChatGPT or document-based tools
+### Zip build for ChatGPT (Code Interpreter) or multi-file tools
 
 Build the standard zip:
 
@@ -50,13 +76,18 @@ What you get:
 * `dist/soulmap-ai.zip`
 * no `.claude-plugin/`
 
-Suggested use:
+Suggested use for ChatGPT with Code Interpreter:
+
+1. Upload `dist/soulmap-ai.zip` directly in a ChatGPT Plus/Pro conversation.
+2. Ask ChatGPT to extract the archive and load `SKILL.md` and `AGENTS.md` as the governing instruction set.
+
+Suggested use for Custom GPT knowledge or Claude Projects:
 
 1. Extract the zip.
 2. Upload the Markdown or text files that match your tool's supported file types.
 3. Point the tool at `SKILL.md`, `AGENTS.md`, and the relevant folders under `skills/` and `templates/`.
 
-### Skill example for skill-oriented tools
+### Skill build for Claude Custom Skills or skill-oriented agents
 
 Build the skill package:
 
@@ -69,11 +100,17 @@ What you get:
 * `dist/soulmap-ai.skill`
 * `.claude-plugin/` preserved
 
-Suggested use:
+Suggested use for Claude Custom Skills:
 
-1. Keep `.claude-plugin/` unchanged.
-2. If your tool expects a directory-based skill install, unpack the archive first.
-3. If your tool accepts packaged skills directly, upload the `.skill` file without modifying its internal paths.
+1. Go to `Customize > Skills` in Claude.ai (requires Pro, Max, Team, or Enterprise with Code Execution enabled).
+2. Click `+` then `Upload a skill`.
+3. Upload `dist/soulmap-ai.skill` directly (or rename to `.zip` if the dialog requires it).
+4. Keep `.claude-plugin/` unchanged inside the archive.
+
+Suggested use for other skill-oriented agents:
+
+1. If your tool expects a directory-based skill install, unpack the archive first.
+2. If your tool accepts packaged skills directly, upload the `.skill` file without modifying its internal paths.
 
 ## Common questions
 


### PR DESCRIPTION
…ll support

ChatGPT:
- Conversations + Code Interpreter (Plus/Pro): ZIP upload is supported and ChatGPT can extract and read contents via the Code Interpreter sandbox
- Custom GPT knowledge: ZIP not supported; upload individual MD/TXT/PDF files

Claude:
- Custom Skills (Pro/Max/Team/Enterprise + code execution): ZIP upload supported via Customize > Skills; .skill archive works directly or renamed .zip
- Conversations and Project knowledge: ZIP not supported; upload individual files

Updated example sections to give concrete step-by-step workflows for each path.

Sources: support.claude.com/articles/12512180, platform.claude.com/docs/agents-and-tools/agent-skills/overview, community.openai.com, datastudios.org